### PR TITLE
Remove primary key

### DIFF
--- a/riemann/database.py
+++ b/riemann/database.py
@@ -20,7 +20,7 @@ class DivisorDb(ABC):
         pass
 
     @abstractmethod
-    def upsert(self, data: List[RiemannDivisorSum]) -> None:
+    def insert(self, data: List[RiemannDivisorSum]) -> None:
         '''Insert or update the given list of data points.'''
         pass
 

--- a/riemann/database.py
+++ b/riemann/database.py
@@ -29,13 +29,6 @@ class DivisorDb(ABC):
         '''Summarize the contents of the database.'''
         pass
 
-
-class SearchMetadataDb(ABC):
-    @abstractmethod
-    def initialize_schema(self):
-        '''Create the schema for a database, idempotently.'''
-        pass
-
     @abstractmethod
     def latest_search_metadata(self, search_state_type: str) -> SearchMetadata:
         pass

--- a/riemann/in_memory_database.py
+++ b/riemann/in_memory_database.py
@@ -2,13 +2,12 @@
 from typing import List
 
 from riemann.database import DivisorDb
-from riemann.database import SearchMetadataDb
 from riemann.types import RiemannDivisorSum
 from riemann.types import SearchMetadata
 from riemann.types import SummaryStats
 
 
-class InMemoryDivisorDb(DivisorDb, SearchMetadataDb):
+class InMemoryDivisorDb(DivisorDb):
     def __init__(self):
         self.data = dict()
         self.metadata = list()

--- a/riemann/in_memory_database.py
+++ b/riemann/in_memory_database.py
@@ -19,7 +19,7 @@ class InMemoryDivisorDb(DivisorDb, SearchMetadataDb):
     def initialize_schema(self):
         pass
 
-    def upsert(self, records: List[RiemannDivisorSum]) -> None:
+    def insert(self, records: List[RiemannDivisorSum]) -> None:
         for record in records:
             self.data[record.n] = record
 

--- a/riemann/populate_database.py
+++ b/riemann/populate_database.py
@@ -40,7 +40,7 @@ def populate_db(divisorDb: DivisorDb, metadataDb: SearchMetadataDb,
     while True:
         start = datetime.now()
         start_state = search_strategy.search_state()
-        db.upsert(search_strategy.next_batch(batch_size))
+        db.insert(search_strategy.next_batch(batch_size))
         end_state = search_strategy.search_state()
         end = datetime.now()
         print(

--- a/riemann/populate_database.py
+++ b/riemann/populate_database.py
@@ -2,7 +2,6 @@
 from datetime import datetime
 
 from riemann.database import DivisorDb
-from riemann.database import SearchMetadataDb
 from riemann.postgres_database import PostgresDivisorDb
 from riemann.search_strategy import search_strategy_by_name
 from riemann.search_strategy import SearchStrategy
@@ -11,7 +10,7 @@ from riemann.types import SearchMetadata
 DEFAULT_BATCH_SIZE = 250000
 
 
-def search_strategy(metadataDb: SearchMetadataDb,
+def search_strategy(divisorDb: DivisorDb,
                     search_strategy_name: str) -> SearchStrategy:
     '''Load the approprate search strategy from the database.
 
@@ -19,7 +18,7 @@ def search_strategy(metadataDb: SearchMetadataDb,
     '''
     search_strategy_class = search_strategy_by_name(search_strategy_name)
     print(f"Searching with strategy {search_strategy_name}")
-    latest_metadata = metadataDb.latest_search_metadata(
+    latest_metadata = divisorDb.latest_search_metadata(
         search_strategy_class().search_state().__class__.__name__)
     if not latest_metadata:
         print("Could not find an existing search state in the DB. "
@@ -31,7 +30,7 @@ def search_strategy(metadataDb: SearchMetadataDb,
     return search_strategy_class().starting_from(starting_search_state)
 
 
-def populate_db(divisorDb: DivisorDb, metadataDb: SearchMetadataDb,
+def populate_db(divisorDb: DivisorDb,
                 search_strategy: SearchStrategy, batch_size: int) -> None:
     '''Populate the db in batches.
 
@@ -46,7 +45,7 @@ def populate_db(divisorDb: DivisorDb, metadataDb: SearchMetadataDb,
         print(
             f"Computed [{start_state.serialize()}, {end_state.serialize()}] in {end-start}"
         )
-        metadataDb.insert_search_metadata(
+        divisorDb.insert_search_metadata(
             SearchMetadata(start_time=start,
                            end_time=end,
                            search_state_type=end_state.__class__.__name__,

--- a/riemann/postgres_database.py
+++ b/riemann/postgres_database.py
@@ -4,7 +4,6 @@ from typing import Union
 import psycopg2.extras
 from gmpy2 import mpz
 from riemann.database import DivisorDb
-from riemann.database import SearchMetadataDb
 from riemann.types import deserialize_search_state
 from riemann.types import RiemannDivisorSum
 from riemann.types import SearchMetadata
@@ -13,7 +12,7 @@ from riemann.types import SummaryStats
 DEFAULT_DATA_SOURCE_NAME = 'dbname=divisor'
 
 
-class PostgresDivisorDb(DivisorDb, SearchMetadataDb):
+class PostgresDivisorDb(DivisorDb):
     '''A database implementation using postgres.'''
 
     def __init__(self, data_source_name=None, data_source_dict=None):

--- a/riemann/postgres_database.py
+++ b/riemann/postgres_database.py
@@ -63,7 +63,7 @@ class PostgresDivisorDb(DivisorDb, SearchMetadataDb):
         ''')
         return self.convert_records(cursor.fetchall())
 
-    def upsert(self, records: List[RiemannDivisorSum]) -> None:
+    def insert(self, records: List[RiemannDivisorSum]) -> None:
         cursor = self.connection.cursor()
         query = '''
         INSERT INTO

--- a/riemann/postgres_database.py
+++ b/riemann/postgres_database.py
@@ -33,7 +33,7 @@ class PostgresDivisorDb(DivisorDb, SearchMetadataDb):
         ''')
         cursor.execute('''
         CREATE TABLE IF NOT EXISTS RiemannDivisorSums (
-            n mpz CONSTRAINT divisor_sum_pk PRIMARY KEY,
+            n mpz,
             divisor_sum mpz,
             witness_value double precision
         );''')
@@ -68,10 +68,7 @@ class PostgresDivisorDb(DivisorDb, SearchMetadataDb):
         query = '''
         INSERT INTO
             RiemannDivisorSums(n, divisor_sum, witness_value)
-            VALUES %s
-        ON CONFLICT(n) DO UPDATE SET
-            divisor_sum=excluded.divisor_sum,
-            witness_value=excluded.witness_value;
+            VALUES %s;
         '''
         template = "(%s::mpz, %s::mpz, %s)"
         arglist = [("%s" % record.n, "%s" % record.divisor_sum,

--- a/test/database_test.py
+++ b/test/database_test.py
@@ -75,21 +75,6 @@ class TestDatabase:
 
         assert set(db.load()) == set(records + new_records)
 
-    def test_upsert_overrides(self, db):
-        records = [
-            RiemannDivisorSum(n=1, divisor_sum=1, witness_value=1),
-            RiemannDivisorSum(n=2, divisor_sum=2, witness_value=2),
-        ]
-        db.upsert(records)
-
-        new_records = [
-            RiemannDivisorSum(n=1, divisor_sum=3, witness_value=3),
-            RiemannDivisorSum(n=4, divisor_sum=4, witness_value=4),
-        ]
-        db.upsert(new_records)
-
-        assert set(db.load()) == set([records[1]] + new_records)
-
     def test_summarize_empty(self, db):
         expected = SummaryStats(largest_computed_n=None,
                                 largest_witness_value=None)

--- a/test/database_test.py
+++ b/test/database_test.py
@@ -49,7 +49,7 @@ class TestDatabase:
             RiemannDivisorSum(n=2, divisor_sum=2, witness_value=2),
         ]
 
-        db.upsert(records)
+        db.insert(records)
         assert set(db.load()) == set(records)
 
     def test_upsert_mpz(self, db):
@@ -57,7 +57,7 @@ class TestDatabase:
             RiemannDivisorSum(n=mpz(1), divisor_sum=mpz(1), witness_value=1),
         ]
 
-        db.upsert(records)
+        db.insert(records)
         assert set(db.load()) == set(records)
 
     def test_upsert_from_nonempty(self, db):
@@ -65,13 +65,13 @@ class TestDatabase:
             RiemannDivisorSum(n=1, divisor_sum=1, witness_value=1),
             RiemannDivisorSum(n=2, divisor_sum=2, witness_value=2),
         ]
-        db.upsert(records)
+        db.insert(records)
 
         new_records = [
             RiemannDivisorSum(n=3, divisor_sum=3, witness_value=3),
             RiemannDivisorSum(n=4, divisor_sum=4, witness_value=4),
         ]
-        db.upsert(new_records)
+        db.insert(new_records)
 
         assert set(db.load()) == set(records + new_records)
 
@@ -86,7 +86,7 @@ class TestDatabase:
             RiemannDivisorSum(n=9, divisor_sum=3, witness_value=3),
             RiemannDivisorSum(n=4, divisor_sum=4, witness_value=4),
         ]
-        db.upsert(records)
+        db.insert(records)
         expected = SummaryStats(largest_computed_n=records[0],
                                 largest_witness_value=records[1])
 

--- a/test/database_test.py
+++ b/test/database_test.py
@@ -4,7 +4,6 @@ import pytest
 import testing.postgresql
 from gmpy2 import mpz
 from riemann.database import DivisorDb
-from riemann.database import SearchMetadataDb
 from riemann.in_memory_database import InMemoryDivisorDb
 from riemann.postgres_database import PostgresDivisorDb
 from riemann.types import ExhaustiveSearchIndex

--- a/timing/ec2_timing_test.py
+++ b/timing/ec2_timing_test.py
@@ -22,7 +22,7 @@ def run_test(batch):
     for i in range(samples):
         print(f'Running sample {i}')
         start = time.time()
-        db.upsert(batch)
+        db.insert(batch)
         end = time.time()
         print(end - start)
         times.append(end - start)


### PR DESCRIPTION
This PR removes the primary key constraint from the RiemannDivisorSums table, and associated cleanup.