### PR TITLE
Store the hash of a search block and only large witness values

### DIFF
--- a/riemann/postgres_database.py
+++ b/riemann/postgres_database.py
@@ -42,7 +42,8 @@ class PostgresDivisorDb(DivisorDb):
             end_time timestamp,
             search_state_type TEXT,
             starting_search_state TEXT,
-            ending_search_state TEXT
+            ending_search_state TEXT,
+            block_hash CHAR(64)
         );''')
         self.connection.commit()
 
@@ -151,16 +152,20 @@ class PostgresDivisorDb(DivisorDb):
               end_time,
               search_state_type,
               starting_search_state,
-              ending_search_state
+              ending_search_state,
+              block_hash
             )
-            VALUES (%s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s)
         '''
 
         cursor.execute(
-            cursor.mogrify(query, (metadata.start_time, metadata.end_time,
-                                   metadata.search_state_type,
-                                   metadata.starting_search_state.serialize(),
-                                   metadata.ending_search_state.serialize())))
+            cursor.mogrify(query, (
+                metadata.start_time,
+                metadata.end_time,
+                metadata.search_state_type,
+                metadata.starting_search_state.serialize(),
+                metadata.ending_search_state.serialize(),
+                metadata.block_hash)))
         self.connection.commit()
 
 

--- a/riemann/types.py
+++ b/riemann/types.py
@@ -2,6 +2,7 @@ from abc import ABC
 from abc import abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
+from hashlib import sha256
 from typing import List
 from typing import Tuple
 
@@ -60,6 +61,11 @@ def deserialize_search_state(search_state_type: str,
             level=int(level), index_in_level=int(index_in_level))
     else:
         raise ValueError(f"Unknown search_state_type {search_state_type}")
+
+
+def hash_divisor_sums(sums: List[RiemannDivisorSum]) -> str:
+    hash_input = ",".join(f"{rds.n},{rds.witness_value:5.4f}" for rds in sums) 
+    return sha256(bytes(hash_input, "utf-8")).hexdigest()
 
 
 @dataclass(frozen=True)

--- a/riemann/types.py
+++ b/riemann/types.py
@@ -69,3 +69,27 @@ class SearchMetadata:
     search_state_type: str
     starting_search_state: SearchState
     ending_search_state: SearchState
+
+    '''
+    The hexdigest of the SHA-256 hash of a string
+    representation of the witness values of this search block.
+    The field may be None if this value has not yet been
+    computed.
+    
+    The format for the string before hashing is
+
+    N_1,WITNESS_VALUE_1,N_2,WITNESS_VALUE_2,...
+
+    where WITNESS_VALUE_i formatted with %5.4f is the approximate witness value
+    for N_i.
+
+    Example, for a block starting with 10080 and ending with 10082, the string
+    before hashing is
+
+    10080,1.7558,100081,0.4775,10082,0.6849
+    
+    And the hash is 
+
+    d6062a3151b57f7a65401cbc41d94239ff150b374269d595d9280849d4e2123f
+    '''
+    block_hash: str = None

--- a/test/types_test.py
+++ b/test/types_test.py
@@ -1,0 +1,17 @@
+from hashlib import sha256
+from riemann.types import RiemannDivisorSum
+from riemann.types import hash_divisor_sums
+import pytest
+
+
+def test_hash_riemann_divisor_sums():
+    sums = [
+        RiemannDivisorSum(n=10080, divisor_sum=39312, witness_value=1.75581),
+        RiemannDivisorSum(n=10081, divisor_sum=10692, witness_value=0.47749),
+        RiemannDivisorSum(n=10082, divisor_sum=15339, witness_value=0.68495),
+    ]
+
+    expected = sha256(
+        bytes("10080,1.7558,10081,0.4775,10082,0.6849", 'utf-8')).hexdigest()
+
+    assert expected == hash_divisor_sums(sums)


### PR DESCRIPTION
This PR modifies the database schema by adding a `block_hash` field to the `SearchMetadata` table. Then the `populate_database` script computes the block hash and stores it, and only stores `RiemannDivisorSum` rows that have witness value > 1.767.