### PR TITLE
Mark blocks as failed when encountering errors

### DIFF
--- a/riemann/database.py
+++ b/riemann/database.py
@@ -50,3 +50,8 @@ class DivisorDb(ABC):
         relevant subset of the corresponding divisor sums.
         '''
         pass
+
+    @abstractmethod
+    def mark_block_as_failed(self, metadata: SearchMetadata) -> None:
+        '''Mark a search block as failed.'''
+        pass

--- a/riemann/in_memory_database.py
+++ b/riemann/in_memory_database.py
@@ -66,6 +66,10 @@ class InMemoryDivisorDb(DivisorDb):
             if divisor_sum.witness_value > self.threshold_witness_value:
                 self.data[divisor_sum.n] = divisor_sum
 
+    def mark_block_as_failed(self, metadata: SearchMetadata) -> None:
+        block = replace(metadata, state=SearchBlockState.FAILED)
+        self.metadata[block.key()] = block
+
     def summarize(self) -> SummaryStats:
         if not self.data:
             return SummaryStats(largest_computed_n=None,

--- a/riemann/postgres_database.py
+++ b/riemann/postgres_database.py
@@ -295,6 +295,26 @@ class PostgresDivisorDb(DivisorDb):
                                        template=template)
         self.connection.commit()
 
+    def mark_block_as_failed(self, metadata: SearchMetadata) -> None:
+        cursor = self.connection.cursor()
+        query = '''
+        UPDATE SearchMetadata
+        SET
+          state = 'FAILED'
+        WHERE
+          search_index_type = %s
+          AND starting_search_index = %s
+          AND ending_search_index = %s
+        ;
+        '''
+
+        cursor.execute(
+            cursor.mogrify(query, (
+                metadata.search_index_type,
+                metadata.starting_search_index.serialize(),
+                metadata.ending_search_index.serialize())))
+        self.connection.commit()
+
 
 if __name__ == "__main__":
     import sys

--- a/test/database_test.py
+++ b/test/database_test.py
@@ -191,6 +191,18 @@ class TestDatabase:
         assert len(stored) == 1
         assert stored[0].n == 2
 
+    def test_mark_in_progress_as_failed(self, db):
+        self.populate_search_blocks(db)
+        block = db.claim_next_search_block(
+            search_index_type='ExhaustiveSearchIndex')
+
+        db.mark_block_as_failed(block)
+        metadata = [
+            x for x in db.load_metadata()
+            if x.starting_search_index == block.starting_search_index
+        ][0]
+        assert metadata.state == SearchBlockState.FAILED
+
     def test_summarize_empty(self, db):
         expected = SummaryStats(largest_computed_n=None,
                                 largest_witness_value=None)


### PR DESCRIPTION
Fixes https://github.com/j2kun/riemann-divisor-sum/issues/14

Now whenever the processor job hits an unexpected exception during block computation, it catches the error and marks the block as failed.