### PR TITLE
Fix performance bug with CachedPartitionsOfN

### DIFF
--- a/riemann/search_strategy.py
+++ b/riemann/search_strategy.py
@@ -104,7 +104,7 @@ class SuperabundantSearchStrategy(SearchStrategy):
     def __init__(self):
         self._search_index = SuperabundantEnumerationIndex(
             level=1, index_in_level=0)
-        self.current_level = [[1]]
+        self.current_level = CachedPartitionsOfN(1)
         self.__maybe_reset_current_level__()
         self._index_name = self._search_index.__class__.__name__
 
@@ -190,6 +190,6 @@ class SuperabundantSearchStrategy(SearchStrategy):
 
     def __maybe_reset_current_level__(self):
         '''Idempotently compute the next level of the enumeration.'''
-        if self.current_level[0] != self._search_index.level:
+        if self.current_level.n != self._search_index.level:
             self.current_level = CachedPartitionsOfN(
                 n=self._search_index.level)


### PR DESCRIPTION
__maybe_reset_current_level__ was using the list form to check
whether the current level matches the stored search index.
Since the current level is now an object (CachedPartitionsOfN)
and its usage is a class-internal implementation detail,
we can just use the .n member variable instead

Fixes https://github.com/j2kun/riemann-divisor-sum/issues/11