### PR TITLE
Add export and plot scripts

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -5,5 +5,5 @@ python_version = 3.7
 
 # Per-module options:
 
-[mypy-gmpy2,numba,psycopg2,psycopg2.extras,testing.postgresql,testing,pytest_cov.embed]
+[mypy-gmpy2,numba,psycopg2,psycopg2.extras,testing.postgresql,testing,pytest_cov.embed,vaex,numpy,matplotlib,matplotlib.pyplot]
 ignore_missing_imports = True

--- a/plot/plot_divisor_sums.py
+++ b/plot/plot_divisor_sums.py
@@ -1,0 +1,27 @@
+import vaex
+import numpy
+import matplotlib.pyplot as plt
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--divisor_sums_csv_path',
+        type=str,
+        help='The csv file containing divisor sum data'
+    )
+    args = parser.parse_args()
+
+    df = vaex.from_csv(args.divisor_sums_csv_path)
+    df['cumulative_max_witness_value'] = numpy.maximum.accumulate(df.witness_value.values)
+
+    # heatmap
+    df.viz.heatmap('log_n', 'witness_value', colormap='coolwarm', show=True)
+    plt.clf()
+
+    # scatterplot
+    x = df.evaluate("log_n")
+    y = df.evaluate("cumulative_max_witness_value")
+    plt.scatter(x, y, c="red", alpha=0.5, s=4)
+    plt.show()

--- a/plot/requirements.txt
+++ b/plot/requirements.txt
@@ -1,0 +1,8 @@
+vaex==4.1.0
+vaex-astro==0.8.0
+vaex-core==4.1.0
+vaex-hdf5==0.7.0
+vaex-jupyter==0.6.0
+vaex-ml==0.11.1
+vaex-server==0.4.0
+vaex-viz==0.5.0

--- a/riemann/database.py
+++ b/riemann/database.py
@@ -1,6 +1,7 @@
 '''An interface for a database containing divisor sums.'''
 from abc import ABC
 from abc import abstractmethod
+from typing import Iterable
 from typing import List
 
 from riemann.types import RiemannDivisorSum
@@ -17,8 +18,13 @@ class DivisorDb(ABC):
         pass
 
     @abstractmethod
-    def load(self) -> List[RiemannDivisorSum]:
-        '''Load the entire database of Riemann divisor sums.'''
+    def load(self) -> Iterable[RiemannDivisorSum]:
+        '''
+        Load the entire database of Riemann divisor sums.
+
+        The result may return a streaming iterator depending on the
+        implementation.
+        '''
         pass
 
     @abstractmethod

--- a/riemann/export_for_plotting.py
+++ b/riemann/export_for_plotting.py
@@ -1,0 +1,39 @@
+'''
+A one-off script that exports the Riemann divisor sums table to a file format
+suitable for plotting.
+'''
+
+from gmpy2 import log
+from riemann.database import DivisorDb
+from riemann.postgres_database import PostgresDivisorDb
+from typing import TextIO
+
+
+def main(divisorDb: DivisorDb, output_file: TextIO) -> None:
+    output_file.write('log_n,log_divisor_sum,witness_value\n')
+    for rds in divisorDb.load():
+        log_n = log(rds.n)
+        log_divisor_sum = log(rds.divisor_sum)
+        output_file.write(
+            f'{log_n:.10f},{log_divisor_sum:.10f},{rds.witness_value:.10f}\n')
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--data_source_name',
+        type=str,
+        help='The psycopg data_source_name string'
+    )
+    parser.add_argument(
+        '--output_file_path',
+        type=str,
+        default='divisor_sums.csv',
+        help='The filepath to write data to (default divisor_sums.csv)'
+    )
+
+    args = parser.parse_args()
+    db = PostgresDivisorDb(data_source_name=args.data_source_name)
+    with open('divisor_sums.csv', 'w') as outfile:
+        main(db, outfile)

--- a/riemann/in_memory_database.py
+++ b/riemann/in_memory_database.py
@@ -1,5 +1,6 @@
 '''A simple in-memory divisor database.'''
 from datetime import datetime
+from typing import Iterable
 from typing import List
 
 from dataclasses import replace
@@ -16,8 +17,8 @@ class InMemoryDivisorDb(DivisorDb):
         self.data = dict()
         self.metadata = dict()
 
-    def load(self) -> List[RiemannDivisorSum]:
-        return list(self.data.values())
+    def load(self) -> Iterable[RiemannDivisorSum]:
+        return self.data.values()
 
     def load_metadata(self) -> List[SearchMetadata]:
         return list(self.metadata.values())

--- a/riemann/postgres_database.py
+++ b/riemann/postgres_database.py
@@ -1,5 +1,6 @@
-from typing import List
 from dataclasses import replace
+from typing import Iterable
+from typing import List
 
 import psycopg2.extras
 from gmpy2 import mpz
@@ -86,14 +87,19 @@ class PostgresDivisorDb(DivisorDb):
             ) for row in rows
         ]
 
-    def load(self) -> List[RiemannDivisorSum]:
-        cursor = self.connection.cursor()
+    def load(self) -> Iterable[RiemannDivisorSum]:
+        cursor = self.connection.cursor("load_divisor_sums")
         cursor.execute('''
             SELECT n, divisor_sum, witness_value
             FROM RiemannDivisorSums
             ORDER BY n asc;
         ''')
-        return self.convert_records(cursor.fetchall())
+        for row in cursor:
+            yield RiemannDivisorSum(
+                n=mpz(row[0]),
+                divisor_sum=mpz(row[1]),
+                witness_value=row[2]
+            )
 
     def load_metadata(self) -> List[SearchMetadata]:
         cursor = self.connection.cursor()

--- a/test/database_test.py
+++ b/test/database_test.py
@@ -58,7 +58,7 @@ class TestDatabase:
         db.insert_search_blocks(metadatas)
 
     def test_initially_empty(self, db):
-        assert len(db.load()) == 0
+        assert len(list(db.load())) == 0
         with pytest.raises(ValueError):
             db.claim_next_search_block(
                 search_index_type='ExhaustiveSearchIndex')
@@ -113,7 +113,7 @@ class TestDatabase:
         ]
 
         db.finish_search_block(block, records)
-        assert len(db.load()) > 0
+        assert len(list(db.load())) > 0
 
         next_block = db.claim_next_search_block(
             search_index_type='ExhaustiveSearchIndex')
@@ -155,7 +155,7 @@ class TestDatabase:
         ]
 
         db.finish_search_block(block, records)
-        stored = db.load()
+        stored = list(db.load())
         assert len(stored) == 1
         assert stored[0].n == 2
 
@@ -187,7 +187,7 @@ class TestDatabase:
         ]
 
         db.finish_search_block(block, records)
-        stored = db.load()
+        stored = list(db.load())
         assert len(stored) == 1
         assert stored[0].n == 2
 

--- a/test/end_to_end_test.py
+++ b/test/end_to_end_test.py
@@ -103,7 +103,7 @@ def test_generate_and_process_blocks_no_duplicates(db_factory):
     metadatas = db.load_metadata()
     assert len(metadatas) > 0
 
-    divisor_sums = db.load()
+    divisor_sums = list(db.load())
     assert len(divisor_sums) > 0
 
     n_values = [d.n for d in divisor_sums]
@@ -157,7 +157,7 @@ def test_multiple_processors_no_duplicates(db_factory):
     for worker in workers:
         worker.close()
 
-    divisor_sums = db.load()
+    divisor_sums = list(db.load())
     assert len(divisor_sums) > 0
 
     n_values = [d.n for d in divisor_sums]


### PR DESCRIPTION
See https://github.com/j2kun/riemann-divisor-sum/issues/31

This applies the export logic and plotting code to provide some basic visualization. It doesn't quite finish #31, because right now it's only applied on the values of n with witness values [above 1.767](https://github.com/j2kun/riemann-divisor-sum/blob/0182a886c21c5c74fe425990ec48d970d313dc32/riemann/database.py#L12)

I'd want to see a plot of the whole space of numbers (which I have on an HDD somewhere).